### PR TITLE
Fix exception on performing a title scan on large files

### DIFF
--- a/src/handbrake/runner.py
+++ b/src/handbrake/runner.py
@@ -173,7 +173,7 @@ class ConvertCommandRunner(CommandRunner):
 class ScanCommandRunner(CommandRunner):
     def __init__(self):
         progress_processor = OutputProcessor(
-            (b"Progress: {", b"}"),
+            (b"Progress: {", b"{"),
             (b"}", b"}"),
             Progress.model_validate_json,
         )


### PR DESCRIPTION
When performing a title scan on large files (which require emitting progress indicators), the handbrake library exceptions on the first progress indicator.

```
2025-12-30 08:21:20,633:handbrake_orch:INFO: Scanning titles in '/media/..../filename.ext'...
Traceback (most recent call last):
  [....vscode debugpy....]
  File "/..../src/handbrake_orch/handbrake_orch/__main__.py", line 185, in <module>
    main()
  File "/..../src/handbrake_orch/handbrake_orch/__main__.py", line 165, in main
    errors = mp.scan()
             ^^^^^^^^^
  File "/..../src/handbrake_orch/handbrake_orch/media_processor.py", line 95, in scan
    title: TitleSet = hb.scan_titles(
                      ^^^^^^^^^^^^^^^
  File "/..../src/handbrake_orch/.venv/lib/python3.12/site-packages/handbrake/__init__.py", line 147, in scan_titles
    for obj in runner.process(self.executable, *args):
  File "/..../src/handbrake_orch/.venv/lib/python3.12/site-packages/handbrake/runner.py", line 132, in process
    o = self.process_line(stdout.rstrip())
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/..../src/handbrake_orch/.venv/lib/python3.12/site-packages/handbrake/runner.py", line 66, in process_line
    res = self.current_processor.convert(b"\n".join(self.collect))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/..../src/handbrake_orch/.venv/lib/python3.12/site-packages/handbrake/runner.py", line 43, in convert
    return self.converter(data)
           ^^^^^^^^^^^^^^^^^^^^
  File "/..../src/handbrake_orch/.venv/lib/python3.12/site-packages/pydantic/main.py", line 766, in model_validate_json
    return cls.__pydantic_validator__.validate_json(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Progress
  Invalid JSON: expected value at line 1 column 1 [type=json_invalid, input_value=b'}\n    "Scanning": {\n ... "State": "SCANNING"\n}', input_type=bytes]
    For further information visit https://errors.pydantic.dev/2.12/v/json_invalid
```

(I did have to edit the exception to redact personal info, I can reproduce it on a cleaner folder if you need that)

This is not caught/covered by a test, which appears to be able to perform a full title scan without emitting a progress marker:
```
$ HandBrakeCLI --json --scan -t 0 -i tests/sample.mp4 2>/dev/null
Version: {
    "Arch": "x86_64",
    "Name": "HandBrake",
    "Official": true,
    "RepoDate": "2023-12-23 21:11:55",
    "RepoHash": "6247edabd251c26f219f08eaab6bd52168b0e99c",
    "System": "Linux",
    "Type": "release",
    "Version": {
        "Major": 1,
        "Minor": 7,
        "Point": 2
    },
    "VersionString": "1.7.2"
}
JSON Title Set: {
    "MainFeature": 0,
    "TitleList": [
        {
            "AngleCount": 1,
            "AudioList": [
```

As far as I can tell, the on-the-fly line editing is intended to put the left curly when replacing the start, but this specific progress indicator had the right curly in the code.

This PR appears to fix this situation on my video file.  Due to personal info, I can't provide a copy of the exact video file, but if you have issues setting up a test case I might be able to come up with a "clean" video.  Also of note - my video is located on a network share, so the file I/O latency is higher than on a local SSD (where the test file likely is typically located).